### PR TITLE
Presto

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,18 @@ services:
       - mongo
       - mysql
 
+  prestoapp:
+    container_name: prestoapp
+    build: ./presto_service
+    ports:
+      - "8080:8080"
+    links:
+      - mongo
+      - mysql
+    depends_on:
+      - mongo
+      - mysql
+
   admin-mongo:
     image: 0x59/admin-mongo:latest
     ports:

--- a/presto_service/Dockerfile
+++ b/presto_service/Dockerfile
@@ -1,0 +1,12 @@
+FROM centos:latest
+RUN yum -y install java-1.8.0-openjdk
+RUN mkdir /data
+RUN mkdir -p /srv/presto/etc/catalog
+WORKDIR /srv/presto
+RUN curl -O https://repo1.maven.org/maven2/com/facebook/presto/presto-server/0.218/presto-server-0.218.tar.gz
+RUN tar xvfz presto-server-0.218.tar.gz
+WORKDIR /srv/presto/presto-server-0.218
+COPY etc/* /srv/presto/presto-server-0.218/etc/
+COPY etc/catalog/* /srv/presto/presto-server-0.218/etc/catalog/
+EXPOSE 8080
+CMD /srv/presto/presto-server-0.218/bin/launcher run

--- a/presto_service/README.md
+++ b/presto_service/README.md
@@ -5,5 +5,34 @@ to use PrestoDB with the MySQL and MongoDB databases from the test environment
 created by Jonathan Dursi.
 
 
-# Installation
+## Installation
+### Presto server Docker setup 
+The Docker container image is setup through the parent `docker-compose`
+configuration file.  Connectors for MySQL and MongoDB have been created with the
+docker-compose configuration in mind and will require changes to the host
+information.
+
+To get the entire container environment running, run the following command:
+
+```
+docker-compose up
+```
+
+Additional steps are required to get the data into each of the MySQL and MongoDB
+databases.  See the README in the parent directory of this repository.
+
+
+
+### Presto client setup
+The Presto client link is available in the documentation link below:
+```
+https://prestodb.github.io/docs/current/installation/cli.html
+```
+
+After downloading the client and changing permissions to make it executable, you
+can start the client by running:
+
+```
+/path/to/client/presto --server localhost:8080
+```
 

--- a/presto_service/README.md
+++ b/presto_service/README.md
@@ -36,3 +36,39 @@ can start the client by running:
 /path/to/client/presto --server localhost:8080
 ```
 
+### Testing the database connections
+Using the previous case for the MySQL database, we can run the same command
+after connecting to the presto server using the client
+
+```
+presto> select count(*) from mysql.var_db.variants;
+ _col0
+-------
+ 19997
+(1 row)
+
+Query 20190425_113636_00012_45fmg, FINISHED, 1 node
+Splits: 18 total, 18 done (100.00%)
+0:03 [20K rows, 0B] [7.26K rows/s, 0B/s]
+```
+
+The MongoDB can be directly queried through Presto using SQL-like syntax.
+
+```
+presto> select count(*) from mongodb.fhir.immunizations;
+ _col0
+-------
+ 13189
+(1 row)
+
+Query 20190425_115119_00013_45fmg, FINISHED, 1 node
+Splits: 18 total, 18 done (100.00%)
+0:04 [13.2K rows, 901B] [3.4K rows/s, 232B/s]
+```
+
+With both databases available in the presto environment, we can perform queries
+across both platforms.
+
+```
+WITH a AS (SELECT variant_id, patient_id FROM mysql.var_db.calls), b AS (SELECT code.text, subject.referenceid FROM mongodb.fhir.conditions), c AS (SELECT variant_id, chrom, start, ref, alt, gene, aa_change FROM mysql.var_db.variants), d AS (SELECT a.*, b.* FROM a JOIN b ON a.patient_id = b.referenceid) SELECT c.*, d.* FROM d JOIN c ON d.variant_id = c.variant_id;
+```

--- a/presto_service/README.md
+++ b/presto_service/README.md
@@ -19,7 +19,17 @@ docker-compose up
 ```
 
 Additional steps are required to get the data into each of the MySQL and MongoDB
-databases.  See the README in the parent directory of this repository.
+databases.  See the README in the parent directory of this repository.  Note
+that a change to the mongodb dump archive was performed to remove problematic
+nested documents in the allergyintolerances, medicationrequests, patients, and
+procedures collections in the fhir database.  The user should run mongorestore
+on the "fixed" file:
+
+```
+cd data/ingest
+tar xvfz mongodb_fhir_dump_fix.tgz
+mongorestore dump
+```
 
 
 
@@ -71,4 +81,21 @@ across both platforms.
 
 ```
 WITH a AS (SELECT variant_id, patient_id FROM mysql.var_db.calls), b AS (SELECT code.text, subject.referenceid FROM mongodb.fhir.conditions), c AS (SELECT variant_id, chrom, start, ref, alt, gene, aa_change FROM mysql.var_db.variants), d AS (SELECT a.*, b.* FROM a JOIN b ON a.patient_id = b.referenceid) SELECT c.*, d.* FROM d JOIN c ON d.variant_id = c.variant_id;
+
+ variant_id | chrom |  start   |          ref          |     alt     | gene | aa_change | variant_id |        patient_id        |                  text                   |       referenceid
+------------+-------+----------+-----------------------+-------------+------+-----------+------------+--------------------------+-----------------------------------------+--------------------------
+      18875 | 21    | 40497889 | T                     | C           | NULL | NULL      |      18875 | 5c8518d9e24090000107787f | Overlapping malignant neoplasm of colon | 5c8518d9e24090000107787f
+      18875 | 21    | 40497889 | T                     | C           | NULL | NULL      |      18875 | 5c8518d9e24090000107787f | Recurrent rectal polyp                  | 5c8518d9e24090000107787f
+      18875 | 21    | 40497889 | T                     | C           | NULL | NULL      |      18875 | 5c8518d9e24090000107787f | Polyp of colon                          | 5c8518d9e24090000107787f
+      18875 | 21    | 40497889 | T                     | C           | NULL | NULL      |      18875 | 5c8518d9e24090000107787f | Acute viral pharyngitis (disorder)      | 5c8518d9e24090000107787f
+      18875 | 21    | 40497889 | T                     | C           | NULL | NULL      |      18875 | 5c8518d9e24090000107787f | Acute viral pharyngitis (disorder)      | 5c8518d9e24090000107787f
+      18875 | 21    | 40497889 | T                     | C           | NULL | NULL      |      18875 | 5c8518d9e24090000107787f | Viral sinusitis (disorder)              | 5c8518d9e24090000107787f
+      18875 | 21    | 40497889 | T                     | C           | NULL | NULL      |      18875 | 5c8518d9e24090000107787f | Osteoporosis (disorder)                 | 5c8518d9e24090000107787f
+      18875 | 21    | 40497889 | T                     | C           | NULL | NULL      |      18875 | 5c8518d9e24090000107787f | Polyp of colon                          | 5c8518d9e24090000107787f
+      18875 | 21    | 40497889 | T                     | C           | NULL | NULL      |      18875 | 5c8518d9e24090000107787f | Prediabetes                             | 5c8518d9e24090000107787f
+      18875 | 21    | 40497889 | T                     | C           | NULL | NULL      |      18875 | 5c8518d9e24090000107787f | Epilepsy                                | 5c8518d9e24090000107787f
+      18875 | 21    | 40497889 | T                     | C           | NULL | NULL      |      18875 | 5c8518d9e24090000107787f | History of single seizure (situation)   | 5c8518d9e24090000107787f
+      18875 | 21    | 40497889 | T                     | C           | NULL | NULL      |      18875 | 5c8518d9e24090000107787f | Seizure disorder                        | 5c8518d9e24090000107787f
+      18879 | 21    | 40499423 | G                     | T           | NULL | NULL      |      18879 | 5c8518d9e24090000107787f | Osteoarthritis of hip                   | 5c8518d9e24090000107787f
+      18879 | 21    | 40499423 | G                     | T           | NULL | NULL      |      18879 | 5c8518d9e24090000107787f | Overlapping malignant neoplasm of colon | 5c8518d9e24090000107787f
 ```

--- a/presto_service/README.md
+++ b/presto_service/README.md
@@ -1,0 +1,9 @@
+# presto_service
+
+The `presto_service` module provides configuration files and setup instructions
+to use PrestoDB with the MySQL and MongoDB databases from the test environment
+created by Jonathan Dursi.
+
+
+# Installation
+

--- a/presto_service/etc/catalog/mongodb.properties
+++ b/presto_service/etc/catalog/mongodb.properties
@@ -1,2 +1,2 @@
 connector.name=mongodb
-mongodb.seeds=127.0.0.1:27017
+mongodb.seeds=mongo:27017

--- a/presto_service/etc/catalog/mongodb.properties
+++ b/presto_service/etc/catalog/mongodb.properties
@@ -1,0 +1,2 @@
+connector.name=mongodb
+mongodb.seeds=127.0.0.1:27017

--- a/presto_service/etc/catalog/mysql.properties
+++ b/presto_service/etc/catalog/mysql.properties
@@ -1,0 +1,4 @@
+connector.name=mysql
+connection-url=jdbc:mysql://127.0.0.1:3306
+connection-user=dbuser
+connection-password=userpass

--- a/presto_service/etc/catalog/mysql.properties
+++ b/presto_service/etc/catalog/mysql.properties
@@ -1,4 +1,4 @@
 connector.name=mysql
-connection-url=jdbc:mysql://127.0.0.1:3306
+connection-url=jdbc:mysql://mysql:3306
 connection-user=dbuser
 connection-password=userpass

--- a/presto_service/etc/config.properties
+++ b/presto_service/etc/config.properties
@@ -1,0 +1,8 @@
+coordinator=true
+node-scheduler.include-coordinator=true
+http-server.http.port=8080
+query.max-memory=5GB
+query.max-memory-per-node=1GB
+query.max-total-memory-per-node=2GB
+discovery-server.enabled=true
+discovery.uri=http://localhost:8080

--- a/presto_service/etc/jvm.config
+++ b/presto_service/etc/jvm.config
@@ -1,0 +1,8 @@
+-server
+-Xmx16G
+-XX:+UseG1GC
+-XX:G1HeapRegionSize=32M
+-XX:+UseGCOverheadLimit
+-XX:+ExplicitGCInvokesConcurrent
+-XX:+HeapDumpOnOutOfMemoryError
+-XX:+ExitOnOutOfMemoryError

--- a/presto_service/etc/log.properties
+++ b/presto_service/etc/log.properties
@@ -1,0 +1,1 @@
+com.facebook.presto=INFO

--- a/presto_service/etc/node.properties
+++ b/presto_service/etc/node.properties
@@ -1,0 +1,3 @@
+node.environment=production
+node.id=BBD719ED-FA6F-4C31-8FFD-0F0EBF6D9AAC
+node.data-dir=/data


### PR DESCRIPTION
Added the PrestoDB service to the test bed to perform queries across multiple database types using a SQL-like language.  Note the change in the MongoDB/fhir dump, this adds a "fixed" version of the dump with the removal of several embedded fields in the allergyintolerances, medicationrequests, patients, and procedures collections.